### PR TITLE
Add conversation reference to messages

### DIFF
--- a/depths/core/database.py
+++ b/depths/core/database.py
@@ -45,9 +45,25 @@ class SwaifDatabase:
                     content TEXT,
                     timestamp DATETIME,
                     ingested_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    processed BOOLEAN DEFAULT FALSE
+                    processed BOOLEAN DEFAULT FALSE,
+                    conversation_id TEXT,
+                    FOREIGN KEY (conversation_id)
+                        REFERENCES conversations_l2(conversation_id)
                 )
             """)
+
+            existing_cols = [c[1] for c in conn.execute("PRAGMA table_info(messages_l1)")]
+            if "conversation_id" not in existing_cols:
+                conn.execute(
+                    "ALTER TABLE messages_l1 ADD COLUMN conversation_id TEXT"
+                )
+
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_messages_l1_conversation_id
+                ON messages_l1(conversation_id)
+                """
+            )
             
             # L2 - Conversas agrupadas
             conn.execute("""

--- a/depths/migrations/202411111200_add_conversation_id_to_messages_l1.sql
+++ b/depths/migrations/202411111200_add_conversation_id_to_messages_l1.sql
@@ -1,0 +1,15 @@
+-- Migration: add conversation_id to messages_l1 and backfill existing data
+ALTER TABLE messages_l1 ADD COLUMN conversation_id TEXT REFERENCES conversations_l2(conversation_id);
+
+CREATE INDEX IF NOT EXISTS idx_messages_l1_conversation_id
+    ON messages_l1(conversation_id);
+
+UPDATE messages_l1
+SET conversation_id = (
+    SELECT c.conversation_id
+    FROM conversations_l2 c
+    WHERE (messages_l1.sender_phone = c.lead_phone AND messages_l1.receiver_phone = c.secretary_phone)
+       OR (messages_l1.sender_phone = c.secretary_phone AND messages_l1.receiver_phone = c.lead_phone)
+    LIMIT 1
+)
+WHERE conversation_id IS NULL;


### PR DESCRIPTION
## Summary
- link L1 messages to their conversations
- backfill conversation IDs via SQL migration

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68a7dd4172948326a338eb1ed718e0c8