### PR TITLE
Refactor temp SQLite handling and add tests

### DIFF
--- a/depths/core/database.py
+++ b/depths/core/database.py
@@ -1,20 +1,20 @@
 import sqlite3
 from pathlib import Path
-from typing import Dict, List, Optional
-from datetime import datetime
-import json
+from typing import Dict
 
 class SwaifDatabase:
     """SQLite handler para as 3 camadas"""
     
     def __init__(self, db_path: str = "data/swaif_msg.db"):
+        self._temp_db = None
         if db_path == ":memory:":
             # Para testes, usar um arquivo temporário em vez de :memory:
             # pois :memory: não persiste entre conexões
             import tempfile
             import os
-            fd, self.db_path = tempfile.mkstemp(suffix='.db')
+            fd, self._temp_db = tempfile.mkstemp(suffix=".db")
             os.close(fd)  # Fechar o file descriptor, usar apenas o path
+            self.db_path = self._temp_db
         else:
             self.db_path = Path(db_path)
             self.db_path.parent.mkdir(exist_ok=True)
@@ -22,12 +22,8 @@ class SwaifDatabase:
     
     def cleanup(self):
         """Remove arquivo temporário (para testes)"""
-        if hasattr(self, '_temp_db') and isinstance(self.db_path, str) and self.db_path.endswith('.db'):
-            import os
-            try:
-                os.unlink(self.db_path)
-            except (FileNotFoundError, PermissionError):
-                pass
+        if self._temp_db:
+            Path(self._temp_db).unlink(missing_ok=True)
     
     def _init_tables(self):
         """Cria tabelas L1, L2, L3"""

--- a/depths/tests/test_database_tempfile.py
+++ b/depths/tests/test_database_tempfile.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from depths.core.database import SwaifDatabase
+
+
+def test_temp_db_created_and_removed():
+    db = SwaifDatabase(":memory:")
+    assert db._temp_db is not None
+    temp_path = Path(db._temp_db)
+    assert temp_path.exists()
+    db.cleanup()
+    assert not temp_path.exists()


### PR DESCRIPTION
## Summary
- track temp DB path and simplify cleanup
- remove unused imports in database layer
- add tests for temp DB creation and cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7f104dbfc83269428c3754c9c8dcb