### PR TITLE
Gracefully handle empty message list

### DIFF
--- a/depths/layers/l2_grouper.py
+++ b/depths/layers/l2_grouper.py
@@ -188,8 +188,10 @@ class L2Grouper:
     
     def _mark_messages_processed(self, message_ids: List[int]):
         """Marca mensagens L1 como processadas"""
+        if not message_ids:
+            return
         with sqlite3.connect(self.db.db_path) as conn:
-            placeholders = ','.join('?' * len(message_ids))
+            placeholders = ','.join(['?'] * len(message_ids))
             conn.execute(
                 f"UPDATE messages_l1 SET processed = TRUE WHERE id IN ({placeholders})",
                 message_ids

--- a/depths/tests/test_l2_grouping.py
+++ b/depths/tests/test_l2_grouping.py
@@ -109,8 +109,13 @@ class TestL2Grouping:
             sender="5511999887766@s.whatsapp.net",
             receiver="5511998681314@s.whatsapp.net"
         )
-        
+
         # Assert
         assert result["lead_phone"] == "5511999887766"
         assert result["secretary_phone"] == "5511998681314"
         assert result["sender_type"] == "lead"
+
+    def test_mark_messages_processed_empty(self):
+        """Test: Deve executar sem erro com lista vazia"""
+        self.grouper._mark_messages_processed([])
+        assert True


### PR DESCRIPTION
## Summary
- Avoid executing SQL when no messages are provided
- Test that marking processed handles empty list without errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7f3f7a710832696fd69375dc1809f