### PR TITLE
Handle missing or malformed JSON in L1 ingestion

### DIFF
--- a/depths/layers/l1_ingestion.py
+++ b/depths/layers/l1_ingestion.py
@@ -23,8 +23,16 @@ class L1Ingestion:
     
     def read_json_file(self, filepath: str) -> List[Dict]:
         """Lê arquivo JSON do N8N"""
-        with open(filepath, 'r', encoding='utf-8') as f:
-            return json.load(f)
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except FileNotFoundError:
+            logger.error(f"File not found: {filepath}")
+            return []
+        except json.JSONDecodeError as e:
+            msg = f"Invalid JSON in {filepath}: {e}"
+            logger.error(msg)
+            raise ValueError(msg) from e
     
     def process_l1_data(self, message_data: Dict) -> Dict:
         """Processa e armazena mensagem L1"""

--- a/depths/tests/test_l1_ingestion.py
+++ b/depths/tests/test_l1_ingestion.py
@@ -1,4 +1,4 @@
-#import pytest
+import pytest
 import json
 import tempfile
 from pathlib import Path
@@ -42,6 +42,28 @@ class TestL1Ingestion:
         
         # Cleanup
         Path(temp_path).unlink()
+
+    def test_read_json_file_missing(self):
+        """Test: Deve retornar lista vazia para arquivo inexistente"""
+        from depths.layers.l1_ingestion import L1Ingestion
+
+        ingestion = L1Ingestion()
+        data = ingestion.read_json_file("arquivo_que_nao_existe.json")
+        assert data == []
+
+    def test_read_json_file_malformed(self):
+        """Test: Deve relançar erro para JSON malformado"""
+        from depths.layers.l1_ingestion import L1Ingestion
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write("{invalid json}")
+            temp_path = f.name
+
+        ingestion = L1Ingestion()
+        with pytest.raises(ValueError):
+            ingestion.read_json_file(temp_path)
+
+        Path(temp_path).unlink()
     
     def test_store_l1_to_database(self):
         """Test: Deve armazenar L1 no SQLite"""
@@ -73,9 +95,9 @@ class TestL1Ingestion:
             # Act - criar arquivo após iniciar monitor
             test_file = Path(tmpdir) / "test_msg.json"
             test_file.write_text(json.dumps(SAMPLE_L1_JSON))
-            
+
             detected_files = ingestion.scan_folder(tmpdir)
-            
+
             # Assert
             assert len(detected_files) == 1
             assert "test_msg.json" in str(detected_files[0])


### PR DESCRIPTION
## Summary
- handle missing files and malformed JSON in `read_json_file`
- test ingestion of missing or malformed JSON files

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a7f3f7a7888326838a7f148b960563