### PR TITLE
Ensure run targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 # SWAIF-MSG Makefile
-.PHONY: help install install-dev test run-depths clean update-deps
+.PHONY: help install install-dev test run-monitor run-pipe run-metrics run-display clean update-deps
 
 help:
 	@echo "SWAIF-MSG Commands:"
 	@echo "  make install      - Install production dependencies"
 	@echo "  make install-dev  - Install all dependencies (including dev)"
-	@echo "  make test        - Run tests"
-	@echo "  make run-depths  - Start depths monitor"
-	@echo "  make clean       - Clean cache files"
-	@echo "  make update-deps - Update requirements.txt"
+	@echo "  make test         - Run tests"
+	@echo "  make run-monitor  - Start depths monitor"
+	@echo "  make run-pipe     - Run depths pipeline"
+	@echo "  make run-metrics  - Generate metrics"
+	@echo "  make run-display  - Launch depths display"
+	@echo "  make clean        - Clean cache files"
+	@echo "  make update-deps  - Update requirements.txt"
 
 install:
 	pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- remove unused `run-depths` entry and document available run targets
- include `run-monitor`, `run-pipe`, `run-metrics`, and `run-display` in `.PHONY`

## Testing
- `pytest depths/tests/ -v --cov=depths`


------
https://chatgpt.com/codex/tasks/task_b_68a7f3fa7bb0832691cc9e65fa3ec6c4