### PR TITLE
Remove duplicate cleanup call in L2 grouping tests

### DIFF
--- a/depths/tests/test_l2_grouping.py
+++ b/depths/tests/test_l2_grouping.py
@@ -1,6 +1,5 @@
 #import pytest
 from datetime import datetime, timedelta
-from pathlib import Path
 from depths.core.database import SwaifDatabase
 from depths.layers.l2_grouper import L2Grouper
 
@@ -12,8 +11,6 @@ class TestL2Grouping:
         self.grouper = L2Grouper(self.db)
 
     def teardown_method(self):
-        db_path = self.db.db_path
-        self.db.cleanup()
         self.db.cleanup()
         
     def test_identify_conversation_id(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning


### PR DESCRIPTION
## Summary
- ensure L2 grouping test teardown only calls cleanup once
- drop unused `Path` import and `db_path` variable
- silence `datetime.datetime.utcfromtimestamp` deprecation warnings in tests

## Testing
- `pytest depths/tests/test_l2_grouping.py -q`
- `pytest depths/tests/test_database_tempfile.py -q`
- `pytest depths/tests/test_l1_ingestion.py -q`
- `pytest --cov=depths -q`


------
https://chatgpt.com/codex/tasks/task_b_68a86df525408326a227345e41b3e645